### PR TITLE
feat: support proxy option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,5 @@ typings/
 .cache
 
 .DS_Store
+
+.idea

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ chat-review --chatgpt sk-xxxxxxxxx --token 'glpat-xxxxxx' --project 200 --mr 200
 - `--model`：ChatGPT 的模型类型，默认为 `gpt-3.5-turbo`。
 - `--language`：ChatGPT 的语言类型，默认为中文。
 - `--host`：GitLab 的访问地址，默认为 `https://gitlab.com`。
+- `--proxyHost`：ChatGPT API host, 默认是 `https://api.openai.com`。
 - `--target`：GitLab Review 的文件，默认为 /\.(j|t)sx?$/
 
 ### CI

--- a/src/chatgpt.ts
+++ b/src/chatgpt.ts
@@ -9,7 +9,7 @@ export default class ChatGPT {
   private request: AxiosInstance;
 
   constructor(config: ChatGPTConfig) {
-    const host = 'https://api.openai.com';
+    const host = config.proxyHost || 'https://api.openai.com';
     this.request = createRequest(host, {
       headers: {
         'Content-Type': 'application/json',

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -28,6 +28,9 @@ cli
   .option('--host <host>', 'gitlab host', {
     default: 'https://gitlab.com',
   })
+  .option('--proxyHost <host>', 'custom chatgpt api host', {
+    default: 'https://api.openai.com',
+  })
   .option('--target [target]', 'review files', {
     default: /\.(j|t)sx?$/,
   })
@@ -37,6 +40,7 @@ cli
       model: string;
       language: string;
       host: string;
+      proxyHost: string;
       token: string;
       project: string | number;
       mr: string | number;
@@ -44,6 +48,7 @@ cli
     }) => {
       const {
         host,
+        proxyHost,
         token,
         project: projectId,
         mr: mrIId,
@@ -65,6 +70,7 @@ cli
             apiKey,
             language,
             model,
+            proxyHost
           },
         });
       } catch (error) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,7 @@ export type ChatGPTConfig = {
   temperature?: number;
   top_p?: number;
   language?: string;
+  proxyHost?: string
 }
 export interface GitlabDiffRef {
   baseSha: string;


### PR DESCRIPTION
我在国内用的时候碰到了 ChatGPT api 请求 443 的问题，似乎是国内被 ban 了。所以换了个代理的地址，这边添加了一个参数支持自定义  ChatGPT api host